### PR TITLE
Updated websocket connection for much faster framerate

### DIFF
--- a/Frontend/insight/src/components/SampleClient.js
+++ b/Frontend/insight/src/components/SampleClient.js
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react'
+import React, { useEffect } from "react";
 
 export default function SampleClient(props) {
-
     let socket = new WebSocket("ws://127.0.0.1:8765/");
     let socketOpen = false;
 
@@ -12,16 +11,20 @@ export default function SampleClient(props) {
     };
 
     socket.onmessage = function (event) {
-        console.log(`[message] Data received from server: ${(event.data).toUpperCase()}`);
+        console.log(
+            `[message] Data received from server: ${event.data.toUpperCase()}`
+        );
     };
 
     socket.onclose = function (event) {
         if (event.wasClean) {
-            console.log(`[close] Connection closed cleanly, code=${event.code} reason=${event.reason}`);
+            console.log(
+                `[close] Connection closed cleanly, code=${event.code} reason=${event.reason}`
+            );
         } else {
             // e.g. server process killed or network down
             // event.code is usually 1006 in this case
-            console.log('[close] Connection died');
+            console.log("[close] Connection died");
         }
         socketOpen = false;
     };
@@ -31,26 +34,20 @@ export default function SampleClient(props) {
     };
 
     // https://stackoverflow.com/questions/65049812/how-to-call-a-function-every-minute-in-a-react-component/65049865
-    const SECOND_MS = 1000;
+    const SECOND_MS = 9; // Rate at which frames are sent to the server, made this lower than the VideoDisplay frame rate to prevent bottlenecks
     useEffect(() => {
         const interval = setInterval(() => {
             if (socketOpen && props.stack.length !== 0) {
                 console.log("Sending packet to server");
-                socket.send(props.stack);
+                // Oldest frames in the image stack array are sent first
+                let item = props.stack.shift();
+                socket.send(item);
                 props.stack.length = 0;
             }
         }, SECOND_MS);
 
         return () => clearInterval(interval);
-    })
+    });
 
-
-    return (
-        <div>
-        </div>
-    )
+    return <div></div>;
 }
-
-
-
-

--- a/Frontend/insight/src/components/VideoDisplay.js
+++ b/Frontend/insight/src/components/VideoDisplay.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from "react";
 import Webcam from "react-webcam";
 
 // const videoDisplay = document.getElementById("video-display");
@@ -13,46 +13,43 @@ import Webcam from "react-webcam";
 
 // Component to display webcam view to the screen along with placeholder when camera is not accessible
 function VideoDisplay(props) {
+    const webcamRef = React.useRef(null);
+    const [imgSrc, setimgSrc] = React.useState(null);
 
-  const webcamRef = React.useRef(null);
-  const [imgSrc, setimgSrc] = React.useState(null);
+    // Capture a screenshot of the current webcam view and add to the imageSrc array
+    const capture = React.useCallback(() => {
+        const imageSrc = webcamRef.current.getScreenshot();
+        setimgSrc(imageSrc);
+        if (imageSrc != null) {
+            console.log("Saving image to array");
+            props.stack.push(imageSrc);
+        }
+    }, [webcamRef, props.stack, setimgSrc]);
 
-  // Capture a screenshot of the current webcam view and add to the imageSrc array
-  const capture = React.useCallback(
-    () => {
-      const imageSrc = webcamRef.current.getScreenshot();
-      setimgSrc(imageSrc)
-      if (imageSrc != null) {
-        console.log("Saving image to array");
-        props.stack.push(imageSrc);
-      }
-    },[webcamRef, props.stack, setimgSrc]
-  );
+    // Repeatedly capture images from the webcam
+    const FRAME_RATE = 10; // Sets the framerate at which images are captured from the camera
+    useEffect(() => {
+        const interval = setInterval(() => {
+            capture();
+        }, FRAME_RATE);
 
-  // Repeatedly capture images from the webcam
-  const FRAME_RATE = 125; // Not completely sure about this number, seems to break the websocket if put much lower
-  useEffect(() => {
-      const interval = setInterval(() => {
-          capture();
-      }, FRAME_RATE);
+        return () => clearInterval(interval);
+    }, [capture]);
 
-      return () => clearInterval(interval);
-  }, [capture])
-  
-
-  return (
-    <div>
-      <Webcam
-        id="video-display"
-        audio={false}
-        ref={webcamRef}
-        screenshotFormat="image/jpeg"
-        height={720}
-        width={1280} />
-      {/* <button onClick={capture}>Capture photo</button>
+    return (
+        <div>
+            <Webcam
+                id="video-display"
+                audio={false}
+                ref={webcamRef}
+                screenshotFormat="image/jpeg"
+                height={720}
+                width={1280}
+            />
+            {/* <button onClick={capture}>Capture photo</button>
       {imgSrc && (<img src={imgSrc} alt="Frame capture"/>) } */}
-    </div>
-  )
+        </div>
+    );
 }
 
-export default VideoDisplay
+export default VideoDisplay;


### PR DESCRIPTION
Made the websocket send only the oldest captured frame at a time instead of all previously captured frames, this seems to allow for much, much faster framerates (at least <~10ms per frame) without crashing the server.